### PR TITLE
feat: Add file listing and filtering by regex functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 # Go workspace file
 go.work
 go.work.sum
+
+.idea/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  timeout: 3m
+
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - zerologlint
+    - gofmt
+    - gocritic
+    - revive
+    - gci
+
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/Kcrong/dir-prompt) # Custom section: groups all imports with the specified Prefix.
+      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+      - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
+    # Skip generated files.
+    skip-generated: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+format:
+	go mod tidy
+	golangci-lint run --fix

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+const (
+	delimiter = "-------------"
+)
+
+func main() {
+	// Define flags
+	regexFlag := flag.String("regex", ".*", "Regex string for filtering files")
+	rootFlag := flag.String("root", ".", "Base path to start file listing")
+	flag.Parse()
+
+	// Compile the regex
+	regex, err := regexp.Compile(*regexFlag)
+	if err != nil {
+		fmt.Println("Invalid regex:", err)
+		return
+	}
+
+	// List files recursively and filter
+	files := listFiles(*rootFlag, regex)
+
+	// Format and print the output
+	printFiles(files)
+}
+
+func listFiles(root string, regex *regexp.Regexp) []string {
+	var files []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && regex.MatchString(info.Name()) {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	if err != nil {
+		fmt.Println("Error listing files:", err)
+	}
+
+	return files
+}
+
+func printFiles(files []string) {
+
+	for i, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Println("Error reading file:", file, err)
+			continue
+		}
+		if i > 0 {
+			fmt.Println(delimiter)
+		}
+		fmt.Printf("Filename: %s\n%s\n", file, string(content))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Kcrong/dir-prompt
+
+go 1.22.4


### PR DESCRIPTION
## Changes
- Added `.idea/` to `.gitignore` to exclude IDE-specific files
- Created `cmd/main.go` with functionality to:
  - Define and parse flags for regex and root directory
  - Compile and validate the provided regex
  - List files recursively from the specified root directory
  - Filter listed files based on the provided regex
  - Read and print the content of filtered files, separated by a delimiter