### PR TITLE
refactor: Update module name and references to dirprompt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters-settings:
     sections:
       - standard # Standard section: captures all standard packages.
       - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/Kcrong/dir-prompt) # Custom section: groups all imports with the specified Prefix.
+      - prefix(github.com/Kcrong/dirprompt) # Custom section: groups all imports with the specified Prefix.
       - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
       - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
       - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dir-prompt
+# dirprompt
 Go-based tool that scans the current directory, parses files, and outputs their filenames and contents in a structured format suitable for Large Language Model (LLM) prompts. Making it easy to integrate into various workflows that require formatted file content for AI processing.
 
 ## Features

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Kcrong/dir-prompt
+module github.com/Kcrong/dirprompt
 
 go 1.22.4


### PR DESCRIPTION
## Changes
- Updated `.golangci.yml` to reflect the renaming of the prefix from `github.com/Kcrong/dir-prompt` to `github.com/Kcrong/dirprompt`
- Updated `README.md` to change the project name from `dir-prompt` to `dirprompt`
- Updated `go.mod` to reflect the module name change from `github.com/Kcrong/dir-prompt` to `github.com/Kcrong/dirprompt`